### PR TITLE
A minor bug fix in the code for cash (in the banking and insurance industry).

### DIFF
--- a/SAF-T_Financial_1.3/Grouping Category Code/CSV/naeringsspesifikasjon.csv
+++ b/SAF-T_Financial_1.3/Grouping Category Code/CSV/naeringsspesifikasjon.csv
@@ -438,7 +438,7 @@ endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.60.20;Andre egenkapitaltransaksjoner - Mottatt konsernbidrag;Other equity transactions – Received group contribution
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.70.00;Andre egenkapitaltransaksjoner - Kundeutbytte;Other equity transactions – Customer dividends
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.90.00;Andre egenkapitaltransaksjoner - Andre;Other equity transactions – Other
-balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;36831;Kontanter;Cash
+balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;1.11.00;Kontanter;Cash
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;1.16.00;Bankinnskudd;Bank deposits
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;2.20.40;Fondsobligasjoner klassifisert som egenkapital;Hybrid capital classified as equity capital
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;2.20.51;Andeler i rentefond;Units in interest funds

--- a/SAF-T_Financial_1.3/Grouping Category Code/XML/naeringsspesifikasjon.xml
+++ b/SAF-T_Financial_1.3/Grouping Category Code/XML/naeringsspesifikasjon.xml
@@ -3516,7 +3516,7 @@
 		<GroupingCategory>balanseverdiForBankOgForsikringseiendel</GroupingCategory>
 		<CategoryDescription ISOLanguageCode="NOB">Næringsspesifikasjon</CategoryDescription>
 		<CategoryDescription ISOLanguageCode="ENG">Income Statement</CategoryDescription>
-		<GroupingCode>01.11.00</GroupingCode>
+		<GroupingCode>1.11.00</GroupingCode>
 		<CodeDescription ISOLanguageCode="NOB">Kontanter</CodeDescription>
 		<CodeDescription ISOLanguageCode="ENG">Cash</CodeDescription>
 	</Account>


### PR DESCRIPTION
A minor bug fix in the code for cash (in the banking and insurance industry). The data type had changed to date. It should be string. Therefore, the numbers had changed. After the fix, the numbers should now be correct.