### PR TITLE
Legger til mapping lister for statlige virksomheter (csv og xml)

### DIFF
--- a/SAF-T_Financial_1.3/Grouping Category Code/CSV/STAT_Grouping_Category_Code.csv
+++ b/SAF-T_Financial_1.3/Grouping Category Code/CSV/STAT_Grouping_Category_Code.csv
@@ -1,0 +1,797 @@
+GroupingCategory;CategoryDescriptionNOB;GroupingCode;CodeDescriptionNOB
+KS;Kontoplan_stat;100;Reservert
+KS;Kontoplan_stat;101;Reservert
+KS;Kontoplan_stat;102;Konsesjoner
+KS;Kontoplan_stat;103;Patenter
+KS;Kontoplan_stat;104;Programvarelisenser og egenutviklet programvare
+KS;Kontoplan_stat;105;Varemerker
+KS;Kontoplan_stat;106;Andre rettigheter
+KS;Kontoplan_stat;107;Immaterielle eiendeler under utførelse
+KS;Kontoplan_stat;108;Reservert
+KS;Kontoplan_stat;109;Reservert
+KS;Kontoplan_stat;110;Bygninger
+KS;Kontoplan_stat;111;Reservert
+KS;Kontoplan_stat;112;Bygningsmessige anlegg
+KS;Kontoplan_stat;113;Anlegg under utførelse
+KS;Kontoplan_stat;114;Jord- og skogbrukseiendommer
+KS;Kontoplan_stat;115;Tomter og andre grunnarealer
+KS;Kontoplan_stat;116;Boliger inkl. tomter
+KS;Kontoplan_stat;117;Infrastruktureiendeler
+KS;Kontoplan_stat;118;Nasjonaleiendom og kulturminner
+KS;Kontoplan_stat;119;Andre anleggsmidler
+KS;Kontoplan_stat;120;Maskiner og anlegg
+KS;Kontoplan_stat;121;Maskiner og anlegg under utførelse
+KS;Kontoplan_stat;122;Skip, rigger, fly
+KS;Kontoplan_stat;123;Biler
+KS;Kontoplan_stat;124;Andre transportmidler
+KS;Kontoplan_stat;125;Inventar
+KS;Kontoplan_stat;126;Fast bygningsinventar med annen avskrivningstid enn bygningen
+KS;Kontoplan_stat;127;Verktøy og lignende
+KS;Kontoplan_stat;128;Datamaskiner og annet IKT-utstyr
+KS;Kontoplan_stat;129;Andre driftsmidler
+KS;Kontoplan_stat;130;Investeringer i datterselskap
+KS;Kontoplan_stat;131;Kapitalinnskudd
+KS;Kontoplan_stat;132;Spesielle beholdninger (kapitalregnskapet)
+KS;Kontoplan_stat;133;Investeringer i tilknyttede selskap
+KS;Kontoplan_stat;134;Obligasjoner (omsettelige verdipapirer)
+KS;Kontoplan_stat;135;Investeringer i aksjer og andeler - kostpris
+KS;Kontoplan_stat;136;Verdiendring av aksjer og andeler
+KS;Kontoplan_stat;137;Utlån (statsbanker)
+KS;Kontoplan_stat;138;Reservert
+KS;Kontoplan_stat;139;Andre langsiktige fordringer
+KS;Kontoplan_stat;140;Råvarer og innkjøpte halvfabrikata
+KS;Kontoplan_stat;141;Reservert
+KS;Kontoplan_stat;142;Varer og driftsmateriell under tilvirkning
+KS;Kontoplan_stat;143;Reservert
+KS;Kontoplan_stat;144;Ferdige egentilvirkede varer og driftsmateriell
+KS;Kontoplan_stat;145;Reservert
+KS;Kontoplan_stat;146;Innkjøpte varer (ferdigvarer) og driftsmateriell
+KS;Kontoplan_stat;147;Innkjøpte varer (ferdigvarer) og driftsmateriell, fortsettelse
+KS;Kontoplan_stat;148;Reservert
+KS;Kontoplan_stat;149;Reservert
+KS;Kontoplan_stat;150;Kundefordringer
+KS;Kontoplan_stat;151;Fordringer vedrørende innkrevingsvirksomhet
+KS;Kontoplan_stat;152;Motpost konto 151
+KS;Kontoplan_stat;153;Opptjent, ikke fakturert driftsinntekt
+KS;Kontoplan_stat;154;Fordring på ansatte
+KS;Kontoplan_stat;155;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;156;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;157;Andre kortsiktige fordringer
+KS;Kontoplan_stat;158;Avsetning tap på fordringer
+KS;Kontoplan_stat;159;Reservert
+KS;Kontoplan_stat;160;Utgående merverdiavgift
+KS;Kontoplan_stat;161;Inngående merverdiavgift
+KS;Kontoplan_stat;162;Reservert
+KS;Kontoplan_stat;163;Reservert
+KS;Kontoplan_stat;164;Oppgjørskonto merverdiavgift
+KS;Kontoplan_stat;165;Reservert
+KS;Kontoplan_stat;166;Reservert
+KS;Kontoplan_stat;167;Reservert
+KS;Kontoplan_stat;168;Reservert
+KS;Kontoplan_stat;169;Reservert
+KS;Kontoplan_stat;170;Forskuddsbetalt leie
+KS;Kontoplan_stat;171;Forskuddsbetalt rente
+KS;Kontoplan_stat;172;Reservert
+KS;Kontoplan_stat;173;Reservert
+KS;Kontoplan_stat;174;Reservert
+KS;Kontoplan_stat;175;Opptjent leieinntekt
+KS;Kontoplan_stat;176;Opptjent renteinntekt
+KS;Kontoplan_stat;177;Reservert
+KS;Kontoplan_stat;178;Reservert
+KS;Kontoplan_stat;179;Andre forskuddsbetalte kostnader
+KS;Kontoplan_stat;180;Kortsiktige finansinvesteringer
+KS;Kontoplan_stat;181;Reservert
+KS;Kontoplan_stat;182;Reservert
+KS;Kontoplan_stat;183;Reservert
+KS;Kontoplan_stat;184;Reservert
+KS;Kontoplan_stat;185;Reservert
+KS;Kontoplan_stat;186;Reservert
+KS;Kontoplan_stat;187;Reservert
+KS;Kontoplan_stat;188;Reservert
+KS;Kontoplan_stat;189;Reservert
+KS;Kontoplan_stat;190;Kontanter
+KS;Kontoplan_stat;191;Andre bankinnskudd (utenfor statens konsernkonto)
+KS;Kontoplan_stat;192;Bankinnskudd utenlandsk valuta (utenfor statens konsernkonto)
+KS;Kontoplan_stat;193;"Bankinnskudd - for oppgjørskonto og arbeidskonto - inn
+(bruttobudsjetterte virksomheter)"
+KS;Kontoplan_stat;194;"Bankinnskudd - for oppgjørskonto og arbeidskonto - ut
+(bruttobudsjetterte virksomheter)"
+KS;Kontoplan_stat;195;"Bankinnskudd - for oppgjørskonto og arbeidskonto - inn og ut
+(bruttobudsjetterte virksomheter)"
+KS;Kontoplan_stat;196;"Bankinnskudd - for oppgjørskonto og arbeidskonto
+(nettobudsjetterte virksomheter)"
+KS;Kontoplan_stat;197;Forvaltningsbedrifter
+KS;Kontoplan_stat;1970;"Mellomværende med statskassen - kontant kap 24xx
+(forvaltningsbedrifter)(IB)"
+KS;Kontoplan_stat;1975;Årets endring i statens rentebærende kapital (forvaltningsbedrifter)
+KS;Kontoplan_stat;1976;Renter av statens faste kapital (forvaltningsbedrifter)
+KS;Kontoplan_stat;1977;Renter av mellomværende med statskassen (forvaltningsbedrifter)
+KS;Kontoplan_stat;1978;Driftsresultat post 24 - Kontant til statskassen
+KS;Kontoplan_stat;198;"Avregning rapporterte transaksjoner til statsregnskapet -
+kontantrelatert"
+KS;Kontoplan_stat;1980;Mellomværende med statskassen - kontant (motpost IB)
+KS;Kontoplan_stat;1981;Spesielle ordninger i staten
+KS;Kontoplan_stat;1982;Reservert
+KS;Kontoplan_stat;1983;Reservert
+KS;Kontoplan_stat;1984;Spesielle statskontoer i kapitalregnskapet
+KS;Kontoplan_stat;1985;Gruppelivsforsikring
+KS;Kontoplan_stat;1986;Arbeidsgiveravgift
+KS;Kontoplan_stat;1987;Nettoføringsordning for mva.
+KS;Kontoplan_stat;1988;Finansskatt på lønn
+KS;Kontoplan_stat;1989;Reservert
+KS;Kontoplan_stat;199;Avregnet med statskassen - andre tidsavgrensningsposter
+KS;Kontoplan_stat;1990;Avregnet med statskassen - andre tidsavgrensningsposter (IB)
+KS;Kontoplan_stat;1991;Inntektsført bevilgning
+KS;Kontoplan_stat;1992;Reservert
+KS;Kontoplan_stat;1996;Reservert
+KS;Kontoplan_stat;1997;Innkrevingsvirksomhet (motpost konto 829, 839 og 849)
+KS;Kontoplan_stat;1998;Tilskuddsforvaltning (motpost konto 859 og 879)
+KS;Kontoplan_stat;1999;"Avregning - resultat av periodens aktiviteter (bruttobudsjetterte
+virksomheter)"
+KS;Kontoplan_stat;200;Innskutt virksomhetskapital
+KS;Kontoplan_stat;201;Reservert
+KS;Kontoplan_stat;202;Innskutt fondskapital
+KS;Kontoplan_stat;203;Reservert
+KS;Kontoplan_stat;204;Reservert
+KS;Kontoplan_stat;205;Opptjent virksomhetskapital
+KS;Kontoplan_stat;206;Egenfinansiering av investeringer (forvaltningsbedrifter)
+KS;Kontoplan_stat;207;Reguleringsfond (forvaltningsbedrifter)
+KS;Kontoplan_stat;208;Opptjent fondskapital
+KS;Kontoplan_stat;209;Egenkapital (kapitalregnskapet)
+KS;Kontoplan_stat;210;Reservert
+KS;Kontoplan_stat;211;Miljøforpliktelser
+KS;Kontoplan_stat;212;Reservert
+KS;Kontoplan_stat;213;Reservert
+KS;Kontoplan_stat;214;Statens rentebærende kapital (forvaltningsbedrifter)
+KS;Kontoplan_stat;215;"Statens finansiering av immaterielle eiendeler og varige driftsmidler
+(nettobudsjetterte virksomheter)"
+KS;Kontoplan_stat;216;"Avregning bevilgningsfinansiert virksomhet (nettobudsjetterte
+virksomheter)"
+KS;Kontoplan_stat;217;Ikke inntektsført bevilgning (nettobudsjetterte virksomheter)
+KS;Kontoplan_stat;218;"Ikke inntektsført tilskudd og overføringer (nettobudsjetterte
+virksomheter)"
+KS;Kontoplan_stat;219;Andre avsetninger for forpliktelser
+KS;Kontoplan_stat;220;Reservert
+KS;Kontoplan_stat;221;Obligasjonslån (omsettelige verdipapirer)
+KS;Kontoplan_stat;222;Gjeld til finansinstitusjoner
+KS;Kontoplan_stat;223;Reservert
+KS;Kontoplan_stat;224;Reservert
+KS;Kontoplan_stat;225;Reservert
+KS;Kontoplan_stat;226;Reservert
+KS;Kontoplan_stat;227;Lånemellomværende med staten (statsbanker)
+KS;Kontoplan_stat;228;Annen langsiktig gjeld
+KS;Kontoplan_stat;229;Annen langsiktig gjeld, fortsettelse
+KS;Kontoplan_stat;230;Reservert
+KS;Kontoplan_stat;231;Reservert
+KS;Kontoplan_stat;232;Obligasjonslån (omsettelige verdipapirer)
+KS;Kontoplan_stat;233;Reservert
+KS;Kontoplan_stat;234;Reservert
+KS;Kontoplan_stat;235;Reservert
+KS;Kontoplan_stat;236;Byggelån
+KS;Kontoplan_stat;237;Reservert
+KS;Kontoplan_stat;238;Andre forpliktelser (kapitalregnskapet)
+KS;Kontoplan_stat;239;Annen gjeld til finansinstitusjoner
+KS;Kontoplan_stat;240;Leverandørgjeld
+KS;Kontoplan_stat;241;Reservert
+KS;Kontoplan_stat;242;Reservert
+KS;Kontoplan_stat;243;Reservert
+KS;Kontoplan_stat;244;Reservert
+KS;Kontoplan_stat;245;Reservert
+KS;Kontoplan_stat;246;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;247;Reservert
+KS;Kontoplan_stat;248;Reservert
+KS;Kontoplan_stat;249;Reservert
+KS;Kontoplan_stat;250;"Gjeld vedrørende tilskuddsforvaltning og andre overføringer fra
+staten"
+KS;Kontoplan_stat;251;"Gjeld vedrørende tilskuddsforvaltning og andre overføringer fra
+staten, fortsettelse"
+KS;Kontoplan_stat;252;Reservert
+KS;Kontoplan_stat;253;Reservert
+KS;Kontoplan_stat;254;Reservert
+KS;Kontoplan_stat;255;Motpost konto 250-251
+KS;Kontoplan_stat;256;Reservert
+KS;Kontoplan_stat;257;Reservert
+KS;Kontoplan_stat;258;Reservert
+KS;Kontoplan_stat;259;Reservert
+KS;Kontoplan_stat;260;Forskuddstrekk
+KS;Kontoplan_stat;261;Påleggstrekk
+KS;Kontoplan_stat;262;Bidragstrekk
+KS;Kontoplan_stat;263;Trygdetrekk/pensjonstrekk (2 %)
+KS;Kontoplan_stat;264;Forsikringstrekk
+KS;Kontoplan_stat;265;Trukket fagforeningskontingent
+KS;Kontoplan_stat;266;Reservert
+KS;Kontoplan_stat;267;Reservert
+KS;Kontoplan_stat;268;Reservert
+KS;Kontoplan_stat;269;Andre trekk
+KS;Kontoplan_stat;270;Utgående merverdiavgift
+KS;Kontoplan_stat;271;Inngående merverdiavgift
+KS;Kontoplan_stat;272;Grunnlag mva. ved innførsel av varer
+KS;Kontoplan_stat;273;Grunnlag mva. ved innførsel av varer, fortsettelse
+KS;Kontoplan_stat;274;Oppgjørskonto merverdiavgift
+KS;Kontoplan_stat;275;Reservert
+KS;Kontoplan_stat;276;Reservert
+KS;Kontoplan_stat;277;Skyldig arbeidsgiveravgift (nettobudsjetterte virksomheter)
+KS;Kontoplan_stat;278;Påløpt arbeidsgiveravgift
+KS;Kontoplan_stat;279;Andre offentlige avgifter
+KS;Kontoplan_stat;280;Avstemmingsdifferanser
+KS;Kontoplan_stat;281;Avsatt pensjonspremie til SPK (arbeidsgiverandel)
+KS;Kontoplan_stat;282;Avstemmingskonto fakturert pensjonspremie fra SPK
+KS;Kontoplan_stat;283;Reservert
+KS;Kontoplan_stat;284;Reservert
+KS;Kontoplan_stat;285;Reservert
+KS;Kontoplan_stat;286;Reservert
+KS;Kontoplan_stat;287;Reservert
+KS;Kontoplan_stat;288;Reservert
+KS;Kontoplan_stat;289;Reservert
+KS;Kontoplan_stat;290;Mottatt forskuddsbetaling
+KS;Kontoplan_stat;291;Gjeld til ansatte
+KS;Kontoplan_stat;292;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;293;Lønn
+KS;Kontoplan_stat;294;Feriepenger
+KS;Kontoplan_stat;295;Påløpte renter
+KS;Kontoplan_stat;296;Påløpte kostnader
+KS;Kontoplan_stat;297;Uopptjent inntekt (motpost kontogruppe 35)
+KS;Kontoplan_stat;298;Avsetning for forpliktelser
+KS;Kontoplan_stat;299;Annen kortsiktig gjeld
+KS;Kontoplan_stat;300;Salgsinntekt varer, avgiftspliktig
+KS;Kontoplan_stat;301;Salgsinntekt varer, avgiftspliktig, fortsettelse
+KS;Kontoplan_stat;302;Reservert
+KS;Kontoplan_stat;303;Salgsinntekt tjenester, avgiftspliktig
+KS;Kontoplan_stat;304;Salgsinntekt tjenester, avgiftspliktig, fortsettelse
+KS;Kontoplan_stat;305;Reservert
+KS;Kontoplan_stat;306;Uttak av varer
+KS;Kontoplan_stat;307;Reservert
+KS;Kontoplan_stat;308;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;309;Reservert
+KS;Kontoplan_stat;310;Salgsinntekt varer, avgiftsfri
+KS;Kontoplan_stat;311;Salgsinntekt varer, avgiftsfri, fortsettelse
+KS;Kontoplan_stat;312;Reservert
+KS;Kontoplan_stat;313;Salgsinntekt tjenester, avgiftsfri
+KS;Kontoplan_stat;314;Salgsinntekt tjenester, avgiftsfri, fortsettelse
+KS;Kontoplan_stat;315;Reservert
+KS;Kontoplan_stat;316;Reservert
+KS;Kontoplan_stat;317;Reservert
+KS;Kontoplan_stat;318;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;319;Reservert
+KS;Kontoplan_stat;320;Salgsinntekt varer, unntatt avgiftsplikt
+KS;Kontoplan_stat;321;Salgsinntekt varer, unntatt avgiftsplikt, fortsettelse
+KS;Kontoplan_stat;322;Reservert
+KS;Kontoplan_stat;323;Salgsinntekt tjenester, unntatt avgiftsplikt
+KS;Kontoplan_stat;324;Salgsinntekt tjenester, unntatt avgiftsplikt, fortsettelse
+KS;Kontoplan_stat;325;Reservert
+KS;Kontoplan_stat;326;Reservert
+KS;Kontoplan_stat;327;Reservert
+KS;Kontoplan_stat;328;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;329;Reservert
+KS;Kontoplan_stat;330;Spesielle offentlige avgifter for tilvirkede/solgte varer
+KS;Kontoplan_stat;331;Reservert
+KS;Kontoplan_stat;332;Reservert
+KS;Kontoplan_stat;333;Reservert
+KS;Kontoplan_stat;334;Reservert
+KS;Kontoplan_stat;335;Reservert
+KS;Kontoplan_stat;336;Reservert
+KS;Kontoplan_stat;337;Reservert
+KS;Kontoplan_stat;338;Reservert
+KS;Kontoplan_stat;339;Reservert
+KS;Kontoplan_stat;340;Tilskudd fra Norges forskningsråd
+KS;Kontoplan_stat;341;Tilskudd fra andre statlige virksomheter
+KS;Kontoplan_stat;342;Tilskudd fra EU
+KS;Kontoplan_stat;343;Tilskudd fra kommunale og fylkeskommunale etater
+KS;Kontoplan_stat;344;Tilskudd fra organisasjoner og stiftelser
+KS;Kontoplan_stat;345;Tilskudd fra næringsliv og private
+KS;Kontoplan_stat;346;Gaver og gaveforsterkninger
+KS;Kontoplan_stat;347;Reservert
+KS;Kontoplan_stat;348;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;349;Andre tilskudd og overføringer
+KS;Kontoplan_stat;350;Garanti
+KS;Kontoplan_stat;351;Service
+KS;Kontoplan_stat;352;Reservert
+KS;Kontoplan_stat;353;Reservert
+KS;Kontoplan_stat;354;Reservert
+KS;Kontoplan_stat;355;Reservert
+KS;Kontoplan_stat;356;Reservert
+KS;Kontoplan_stat;357;Reservert
+KS;Kontoplan_stat;358;Reservert
+KS;Kontoplan_stat;359;Reservert
+KS;Kontoplan_stat;360;Leieinntekt fast eiendom
+KS;Kontoplan_stat;361;Leieinntekt fast eiendom, fortsettelse
+KS;Kontoplan_stat;362;Leieinntekt fast eiendom, fortsettelse
+KS;Kontoplan_stat;363;Leieinntekt andre varige driftsmidler
+KS;Kontoplan_stat;364;Annen leieinntekt
+KS;Kontoplan_stat;365;Reservert
+KS;Kontoplan_stat;366;Reservert
+KS;Kontoplan_stat;367;Annen driftsrelatert inntekt
+KS;Kontoplan_stat;368;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;369;Reservert
+KS;Kontoplan_stat;370;Gebyrer med videre - driftsinntekt
+KS;Kontoplan_stat;371;Gebyrer med videre - driftsinntekt, fortsettelse
+KS;Kontoplan_stat;372;Gebyrer med videre - driftsinntekt, fortsettelse
+KS;Kontoplan_stat;373;Gebyrer med videre - driftsinntekt, fortsettelse
+KS;Kontoplan_stat;374;Gebyrer med videre - driftsinntekt, fortsettelse
+KS;Kontoplan_stat;375;Gebyrinntekt krevd inn på vegne av andre statlige virksomheter
+KS;Kontoplan_stat;376;Reservert
+KS;Kontoplan_stat;377;Reservert
+KS;Kontoplan_stat;378;Reservert
+KS;Kontoplan_stat;379;Avregning konto 375
+KS;Kontoplan_stat;380;Salgssum ved avgang anleggsmidler
+KS;Kontoplan_stat;381;Gevinst ved avgang av anleggsmidler
+KS;Kontoplan_stat;382;Reservert
+KS;Kontoplan_stat;383;Reservert
+KS;Kontoplan_stat;384;Reservert
+KS;Kontoplan_stat;385;Bokført verdi avhendede anleggsmidler
+KS;Kontoplan_stat;386;Reservert
+KS;Kontoplan_stat;387;Overført til tap ved avgang av anleggsmidler (konto 780)
+KS;Kontoplan_stat;388;Reservert
+KS;Kontoplan_stat;389;Reservert
+KS;Kontoplan_stat;390;Inntekt fra bevilgninger
+KS;Kontoplan_stat;391;"Inntektsført bevilgning benyttet til investering (debitering)
+(nettobudsjetterte virksomheter)"
+KS;Kontoplan_stat;392;Reservert
+KS;Kontoplan_stat;393;Reservert
+KS;Kontoplan_stat;394;Reservert
+KS;Kontoplan_stat;395;"Inntektsføring av avsetning knyttet til anleggsmidler (avskrivninger)
+(nettobudsjetterte virksomheter)"
+KS;Kontoplan_stat;396;"Inntektsføring av resterende avsetning ved avgang anleggsmidler
+(nettobudsjetterte virksomheter)"
+KS;Kontoplan_stat;397;Reservert
+KS;Kontoplan_stat;398;Andre inntekter fra bevilgninger
+KS;Kontoplan_stat;399;Reservert
+KS;Kontoplan_stat;400;Innkjøp av råvarer og halvfabrikater
+KS;Kontoplan_stat;401;Innkjøp av råvarer og halvfabrikater, fortsettelse
+KS;Kontoplan_stat;402;Innkjøp av råvarer og halvfabrikater, fortsettelse
+KS;Kontoplan_stat;403;Innkjøp av råvarer og halvfabrikater, fortsettelse
+KS;Kontoplan_stat;404;Reservert
+KS;Kontoplan_stat;405;Reservert
+KS;Kontoplan_stat;406;Frakt, toll og spedisjon
+KS;Kontoplan_stat;407;Reservert
+KS;Kontoplan_stat;408;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;409;Beholdningsendring
+KS;Kontoplan_stat;410;Varer under tilvirkning
+KS;Kontoplan_stat;411;Varer under tilvirkning, fortsettelse
+KS;Kontoplan_stat;412;Varer under tilvirkning, fortsettelse
+KS;Kontoplan_stat;413;Varer under tilvirkning, fortsettelse
+KS;Kontoplan_stat;414;Reservert
+KS;Kontoplan_stat;415;Reservert
+KS;Kontoplan_stat;416;Frakt, toll og spedisjon
+KS;Kontoplan_stat;417;Reservert
+KS;Kontoplan_stat;418;Reservert
+KS;Kontoplan_stat;419;Beholdningsendring
+KS;Kontoplan_stat;420;Ferdig egentilvirkede varer
+KS;Kontoplan_stat;421;Ferdig egentilvirkede varer, fortsettelse
+KS;Kontoplan_stat;422;Ferdig egentilvirkede varer, fortsettelse
+KS;Kontoplan_stat;423;Ferdig egentilvirkede varer, fortsettelse
+KS;Kontoplan_stat;424;Reservert
+KS;Kontoplan_stat;425;Reservert
+KS;Kontoplan_stat;426;Frakt, toll og spedisjon
+KS;Kontoplan_stat;427;Reservert
+KS;Kontoplan_stat;428;Reservert
+KS;Kontoplan_stat;429;Beholdningsendring
+KS;Kontoplan_stat;430;Forbruk av innkjøpte varer og tjenester
+KS;Kontoplan_stat;431;Forbruk av innkjøpte varer og tjenester, fortsettelse
+KS;Kontoplan_stat;432;Forbruk av innkjøpte varer og tjenester, fortsettelse
+KS;Kontoplan_stat;433;Forbruk av innkjøpte varer og tjenester, fortsettelse
+KS;Kontoplan_stat;434;Forbruk av innkjøpte varer og tjenester, fortsettelse
+KS;Kontoplan_stat;435;Forbruk av innkjøpte varer og tjenester, fortsettelse
+KS;Kontoplan_stat;436;Forbruk av innkjøpte varer og tjenester, fortsettelse
+KS;Kontoplan_stat;437;Forbruk av innkjøpte varer og tjenester, fortsettelse
+KS;Kontoplan_stat;438;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;439;Beholdningsendring
+KS;Kontoplan_stat;450;Fremmedytelse og underentreprise
+KS;Kontoplan_stat;451;Fremmedytelse og underentreprise, fortsettelse
+KS;Kontoplan_stat;452;Fremmedytelse og underentreprise, fortsettelse
+KS;Kontoplan_stat;453;Fremmedytelse og underentreprise, fortsettelse
+KS;Kontoplan_stat;454;Fremmedytelse og underentreprise, fortsettelse
+KS;Kontoplan_stat;455;Reservert
+KS;Kontoplan_stat;456;Reservert
+KS;Kontoplan_stat;457;Reservert
+KS;Kontoplan_stat;458;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;459;Beholdningsendring
+KS;Kontoplan_stat;460;Annen periodisering
+KS;Kontoplan_stat;461;Reservert
+KS;Kontoplan_stat;462;Reservert
+KS;Kontoplan_stat;463;Reservert
+KS;Kontoplan_stat;464;Reservert
+KS;Kontoplan_stat;465;Reservert
+KS;Kontoplan_stat;466;Reservert
+KS;Kontoplan_stat;467;Reservert
+KS;Kontoplan_stat;468;Reservert
+KS;Kontoplan_stat;469;Beholdningsendring, egentilvirkede anleggsmidler
+KS;Kontoplan_stat;470;Reservert
+KS;Kontoplan_stat;471;Reservert
+KS;Kontoplan_stat;472;Konsesjoner
+KS;Kontoplan_stat;473;Patenter
+KS;Kontoplan_stat;474;Programvarelisenser
+KS;Kontoplan_stat;475;Varemerker
+KS;Kontoplan_stat;476;Andre rettigheter
+KS;Kontoplan_stat;477;Reservert
+KS;Kontoplan_stat;478;Reservert
+KS;Kontoplan_stat;479;Reservert
+KS;Kontoplan_stat;480;Bygninger
+KS;Kontoplan_stat;481;Reservert
+KS;Kontoplan_stat;482;Bygningsmessige anlegg
+KS;Kontoplan_stat;483;Reservert
+KS;Kontoplan_stat;484;Jord- og skogbrukseiendommer
+KS;Kontoplan_stat;485;Tomter og andre grunnarealer
+KS;Kontoplan_stat;486;Boliger inkl. tomter
+KS;Kontoplan_stat;487;Infrastruktureiendeler
+KS;Kontoplan_stat;488;Nasjonaleiendom og kulturminner
+KS;Kontoplan_stat;489;Andre anleggsmidler
+KS;Kontoplan_stat;490;Maskiner og anlegg
+KS;Kontoplan_stat;491;Reservert
+KS;Kontoplan_stat;492;Skip, rigger, fly
+KS;Kontoplan_stat;493;Biler
+KS;Kontoplan_stat;494;Andre transportmidler
+KS;Kontoplan_stat;495;Inventar
+KS;Kontoplan_stat;496;Fast bygningsinventar med annen levetid enn bygningen
+KS;Kontoplan_stat;497;Verktøy og lignende
+KS;Kontoplan_stat;498;Datamaskiner  og annet IKT-utstyr
+KS;Kontoplan_stat;499;Andre driftsmidler
+KS;Kontoplan_stat;500;Lønn fast ansatte
+KS;Kontoplan_stat;501;Lønn fast ansatte, fortsettelse
+KS;Kontoplan_stat;502;Lønn fast ansatte, fortsettelse
+KS;Kontoplan_stat;503;Lønn fast ansatte, fortsettelse
+KS;Kontoplan_stat;504;Lønn balanseført ved egenutvikling av anleggsmidler
+KS;Kontoplan_stat;505;Overtid fast ansatte
+KS;Kontoplan_stat;506;Overtid fast ansatte, fortsettelse
+KS;Kontoplan_stat;507;Reservert
+KS;Kontoplan_stat;508;Feriepenger
+KS;Kontoplan_stat;509;Periodiseringskonto lønn
+KS;Kontoplan_stat;510;Lønn midlertidig ansatte
+KS;Kontoplan_stat;511;Lønn midlertidig ansatte, fortsettelse
+KS;Kontoplan_stat;512;Lønn midlertidig ansatte, fortsettelse
+KS;Kontoplan_stat;513;Lønn midlertidig ansatte, fortsettelse
+KS;Kontoplan_stat;514;Reservert
+KS;Kontoplan_stat;515;Overtid midlertidig ansatte
+KS;Kontoplan_stat;516;Overtid midlertidig ansatte, fortsettelse
+KS;Kontoplan_stat;517;Reservert
+KS;Kontoplan_stat;518;Feriepenger
+KS;Kontoplan_stat;519;Periodiseringskonto lønn
+KS;Kontoplan_stat;520;Fri bil
+KS;Kontoplan_stat;521;Fri elektronisk kommunikasjon (telefon, mobiltelefon mv.)
+KS;Kontoplan_stat;522;Fri avis
+KS;Kontoplan_stat;523;Fri losji og bolig
+KS;Kontoplan_stat;524;Rentefordel
+KS;Kontoplan_stat;525;Gruppelivsforsikring
+KS;Kontoplan_stat;526;Reservert
+KS;Kontoplan_stat;527;Reservert
+KS;Kontoplan_stat;528;Annen fordel i arbeidsforhold
+KS;Kontoplan_stat;529;Motkonto for gruppe 52
+KS;Kontoplan_stat;530;Styrer, råd og utvalg
+KS;Kontoplan_stat;531;Styrer, råd og utvalg, fortsettelse
+KS;Kontoplan_stat;532;Reservert
+KS;Kontoplan_stat;533;Honorarer
+KS;Kontoplan_stat;534;Honorarer, fortsettelse
+KS;Kontoplan_stat;535;Reservert
+KS;Kontoplan_stat;536;"Virkemidler ved omstilling i staten (lønnsinnberettet av
+virksomheten)"
+KS;Kontoplan_stat;537;Reservert
+KS;Kontoplan_stat;538;Reservert
+KS;Kontoplan_stat;539;Annen oppgavepliktig godtgjørelse
+KS;Kontoplan_stat;540;Arbeidsgiveravgift innberettede ytelser
+KS;Kontoplan_stat;541;Arbeidsgiveravgift påløpte ytelser
+KS;Kontoplan_stat;542;Pensjonspremie til SPK
+KS;Kontoplan_stat;543;Reservert
+KS;Kontoplan_stat;544;Pensjonspremie for pensjonsordninger utenfor SPK
+KS;Kontoplan_stat;545;Reservert
+KS;Kontoplan_stat;546;Inntekter til pensjonsordninger i staten (kun til bruk for SPK)
+KS;Kontoplan_stat;547;Utgifter til pensjonsordninger i staten (kun til bruk for SPK)
+KS;Kontoplan_stat;548;"Utgifter til pensjonsordninger i staten (kun til bruk for SPK),
+fortsettelse"
+KS;Kontoplan_stat;549;Finansskatt på lønn
+KS;Kontoplan_stat;550;Annen kostnadsgodtgjørelse
+KS;Kontoplan_stat;551;Reservert
+KS;Kontoplan_stat;552;Reservert
+KS;Kontoplan_stat;553;Godtgjørelse til innkalte, klienter og innsatte m.m.
+KS;Kontoplan_stat;554;Godtgjørelse til innkalte, klienter og innsatte m.m., fortsettelse
+KS;Kontoplan_stat;555;Godtgjørelse til innkalte, klienter og innsatte m.m., fortsettelse
+KS;Kontoplan_stat;556;Reservert
+KS;Kontoplan_stat;557;Ventelønn (lønnsinnberettet av andre enn virksomheten)
+KS;Kontoplan_stat;558;Reservert
+KS;Kontoplan_stat;559;Reservert
+KS;Kontoplan_stat;570;Lærlingtilskudd
+KS;Kontoplan_stat;571;Arbeidsmarkedstiltak
+KS;Kontoplan_stat;572;Tilretteleggingstilskudd
+KS;Kontoplan_stat;573;Reservert
+KS;Kontoplan_stat;574;Reservert
+KS;Kontoplan_stat;575;Reservert
+KS;Kontoplan_stat;576;Reservert
+KS;Kontoplan_stat;577;Reservert
+KS;Kontoplan_stat;578;Reservert
+KS;Kontoplan_stat;579;Andre offentlige tilskudd
+KS;Kontoplan_stat;580;Refusjon av sykepenger
+KS;Kontoplan_stat;581;Refusjon av foreldrepenger
+KS;Kontoplan_stat;582;Reservert
+KS;Kontoplan_stat;583;Reservert
+KS;Kontoplan_stat;584;Reservert
+KS;Kontoplan_stat;585;Reservert
+KS;Kontoplan_stat;586;Reservert
+KS;Kontoplan_stat;587;Reservert
+KS;Kontoplan_stat;588;Reservert
+KS;Kontoplan_stat;589;Annen refusjon vedrørende arbeidskraft
+KS;Kontoplan_stat;590;Gaver til ansatte
+KS;Kontoplan_stat;591;Kantinekostnad
+KS;Kontoplan_stat;592;Gruppelivsforsikring
+KS;Kontoplan_stat;593;Yrkesskadepremie
+KS;Kontoplan_stat;594;Reservert
+KS;Kontoplan_stat;595;Reservert
+KS;Kontoplan_stat;596;Velferdstiltak
+KS;Kontoplan_stat;597;Reservert
+KS;Kontoplan_stat;598;Reservert
+KS;Kontoplan_stat;599;Annen personalkostnad
+KS;Kontoplan_stat;600;Avskrivning på immaterielle eiendeler
+KS;Kontoplan_stat;601;Avskrivning på bygninger og annen fast eiendom
+KS;Kontoplan_stat;602;Avskrivning på bygninger og annen fast eiendom, fortsettelse
+KS;Kontoplan_stat;603;Avskrivning på infrastruktureiendeler
+KS;Kontoplan_stat;604;Avskrivning på maskiner og transportmidler
+KS;Kontoplan_stat;605;Avskrivning på driftsløsøre, inventar, verktøy o.l.
+KS;Kontoplan_stat;606;Reservert
+KS;Kontoplan_stat;607;Nedskrivning av varige driftsmidler og immaterielle eiendeler
+KS;Kontoplan_stat;608;Reservert
+KS;Kontoplan_stat;609;Reservert
+KS;Kontoplan_stat;610;Frakt, transport og forsikring ved vareforsendelse
+KS;Kontoplan_stat;611;Toll og spedisjon ved vareforsendelse
+KS;Kontoplan_stat;612;Reservert
+KS;Kontoplan_stat;613;Reservert
+KS;Kontoplan_stat;614;Frakt, transport m.m. ved utdeling av driftsmateriell
+KS;Kontoplan_stat;615;Reservert
+KS;Kontoplan_stat;616;Reservert
+KS;Kontoplan_stat;617;Reservert
+KS;Kontoplan_stat;618;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;619;Annen frakt- og transportkostnad ved salg
+KS;Kontoplan_stat;620;Elektrisitet
+KS;Kontoplan_stat;621;Gass
+KS;Kontoplan_stat;622;Fyringsolje
+KS;Kontoplan_stat;623;Kull, koks
+KS;Kontoplan_stat;624;Ved
+KS;Kontoplan_stat;625;Bensin, diesel
+KS;Kontoplan_stat;626;Vann
+KS;Kontoplan_stat;627;Reservert
+KS;Kontoplan_stat;628;Reservert
+KS;Kontoplan_stat;629;Annet brensel
+KS;Kontoplan_stat;630;Leie lokaler
+KS;Kontoplan_stat;631;Leie lokaler fra Statsbygg
+KS;Kontoplan_stat;632;Renovasjon, vann, avløp o.l.
+KS;Kontoplan_stat;633;Reservert
+KS;Kontoplan_stat;634;Lys, varme
+KS;Kontoplan_stat;635;Reservert
+KS;Kontoplan_stat;636;Renhold, vakthold, vaktmestertjenester
+KS;Kontoplan_stat;637;Reservert
+KS;Kontoplan_stat;638;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;639;Annen kostnad lokaler
+KS;Kontoplan_stat;640;Leie maskiner
+KS;Kontoplan_stat;641;Leie inventar
+KS;Kontoplan_stat;642;Leie av datasystemer (årlige lisenser m.m.)
+KS;Kontoplan_stat;643;Leie av datamaskiner og annet IKT-utstyr
+KS;Kontoplan_stat;644;Leie av andre kontormaskiner
+KS;Kontoplan_stat;645;Leie av biler
+KS;Kontoplan_stat;646;Leie av andre transportmidler
+KS;Kontoplan_stat;647;Reservert
+KS;Kontoplan_stat;648;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;649;Annen leiekostnad
+KS;Kontoplan_stat;650;Maskiner
+KS;Kontoplan_stat;651;Verktøy og lignende
+KS;Kontoplan_stat;652;Programvare (anskaffelse)
+KS;Kontoplan_stat;653;Reservert
+KS;Kontoplan_stat;654;Inventar
+KS;Kontoplan_stat;655;"Datamaskiner og annet IKT-utstyr (PCer, mobiltelefoner, nettbrett
+m.m.)"
+KS;Kontoplan_stat;656;Andre kontormaskiner
+KS;Kontoplan_stat;657;Arbeidsklær og verneutstyr
+KS;Kontoplan_stat;658;Annet driftsmateriale
+KS;Kontoplan_stat;659;Annet driftsmateriale, fortsettelse
+KS;Kontoplan_stat;660;Reparasjon og vedlikehold egne bygninger
+KS;Kontoplan_stat;661;Reparasjon og vedlikehold egne bygninger, fortsettelse
+KS;Kontoplan_stat;662;Reparasjon og vedlikehold egne bygninger, fortsettelse
+KS;Kontoplan_stat;663;Reparasjon og vedlikehold leide lokaler
+KS;Kontoplan_stat;664;Reparasjon og vedlikehold infrastruktureiendeler
+KS;Kontoplan_stat;665;Reparasjon og vedlikehold infrastruktureiendeler, fortsettelse
+KS;Kontoplan_stat;666;Reparasjon og vedlikehold maskiner og anlegg
+KS;Kontoplan_stat;667;Reparasjon og vedlikehold maskiner og anlegg, fortsettelse
+KS;Kontoplan_stat;668;Reparasjon og vedlikehold skip, rigger, fly
+KS;Kontoplan_stat;669;Reparasjon og vedlikehold annet
+KS;Kontoplan_stat;670;Konsulenttjenester innen økonomi, revisjon og juss
+KS;Kontoplan_stat;671;Konsulenttjenester til utvikling av programvare, IKT-løsninger mv.
+KS;Kontoplan_stat;672;"Konsulenttjenester til organisasjonsutvikling,
+kommunikasjonsrådgivning mv."
+KS;Kontoplan_stat;673;Andre konsulenttjenester
+KS;Kontoplan_stat;674;Innleie av vikarer
+KS;Kontoplan_stat;675;Kjøp av tjenester til løpende driftsoppgaver, IKT
+KS;Kontoplan_stat;676;Kjøp av lønns- og regnskapstjenester
+KS;Kontoplan_stat;677;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;678;Kjøp av andre fremmede tjenester
+KS;Kontoplan_stat;679;Kjøp av andre fremmede tjenester, fortsettelse
+KS;Kontoplan_stat;680;Kontorrekvisita
+KS;Kontoplan_stat;681;Reservert
+KS;Kontoplan_stat;682;Trykksak
+KS;Kontoplan_stat;683;Annonser, kunngjøringer
+KS;Kontoplan_stat;684;Aviser, tidsskrifter, bøker o.l.
+KS;Kontoplan_stat;685;Aviser, tidsskrifter, bøker o.l. i bibliotek
+KS;Kontoplan_stat;686;Møter
+KS;Kontoplan_stat;687;Kurs og seminarer for egne ansatte
+KS;Kontoplan_stat;688;Kurs og seminarer for eksterne deltakere
+KS;Kontoplan_stat;689;Annen kontorkostnad
+KS;Kontoplan_stat;690;Telefoni og datakommunikasjon, samband, internett
+KS;Kontoplan_stat;691;Reservert
+KS;Kontoplan_stat;692;Reservert
+KS;Kontoplan_stat;693;Reservert
+KS;Kontoplan_stat;694;Porto
+KS;Kontoplan_stat;695;Reservert
+KS;Kontoplan_stat;696;Reservert
+KS;Kontoplan_stat;697;Reservert
+KS;Kontoplan_stat;698;Reservert
+KS;Kontoplan_stat;699;Reservert
+KS;Kontoplan_stat;700;Drivstoff
+KS;Kontoplan_stat;701;Reservert
+KS;Kontoplan_stat;702;Vedlikehold
+KS;Kontoplan_stat;703;Reservert
+KS;Kontoplan_stat;704;Forsikring
+KS;Kontoplan_stat;705;Reservert
+KS;Kontoplan_stat;706;Reservert
+KS;Kontoplan_stat;707;Reservert
+KS;Kontoplan_stat;708;Reservert
+KS;Kontoplan_stat;709;Annen kostnad transportmidler
+KS;Kontoplan_stat;710;Bilgodtgjørelse
+KS;Kontoplan_stat;711;Reservert
+KS;Kontoplan_stat;712;Reservert
+KS;Kontoplan_stat;713;Reisekostnad
+KS;Kontoplan_stat;714;Reisekostnad, fortsettelse
+KS;Kontoplan_stat;715;Diettkostnad
+KS;Kontoplan_stat;716;Diettkostnad, fortsettelse
+KS;Kontoplan_stat;717;Reservert
+KS;Kontoplan_stat;718;Reservert
+KS;Kontoplan_stat;719;Annen kostnadsgodtgjørelse
+KS;Kontoplan_stat;730;Salgskostnad
+KS;Kontoplan_stat;731;Reservert
+KS;Kontoplan_stat;732;Reklame- og markedsføringskostnader
+KS;Kontoplan_stat;733;Reservert
+KS;Kontoplan_stat;734;Reservert
+KS;Kontoplan_stat;735;Representasjon
+KS;Kontoplan_stat;736;Reservert
+KS;Kontoplan_stat;737;Reservert
+KS;Kontoplan_stat;738;Reservert
+KS;Kontoplan_stat;739;Reservert
+KS;Kontoplan_stat;740;Kontingent
+KS;Kontoplan_stat;741;Gave
+KS;Kontoplan_stat;742;Reservert
+KS;Kontoplan_stat;743;Reservert
+KS;Kontoplan_stat;744;Reservert
+KS;Kontoplan_stat;745;Reservert
+KS;Kontoplan_stat;746;Reservert
+KS;Kontoplan_stat;747;Reservert
+KS;Kontoplan_stat;748;Reservert
+KS;Kontoplan_stat;749;Reservert
+KS;Kontoplan_stat;750;Forsikringspremie
+KS;Kontoplan_stat;751;Reservert
+KS;Kontoplan_stat;752;Reservert
+KS;Kontoplan_stat;753;Reservert
+KS;Kontoplan_stat;754;Reservert
+KS;Kontoplan_stat;755;Garantikostnad
+KS;Kontoplan_stat;756;Servicekostnad
+KS;Kontoplan_stat;757;Reservert
+KS;Kontoplan_stat;758;Reservert
+KS;Kontoplan_stat;759;Reservert
+KS;Kontoplan_stat;760;Lisensavgift og royalties (ikke programvarelisenser, jf. 642)
+KS;Kontoplan_stat;761;Patentkostnad ved egen patent
+KS;Kontoplan_stat;762;Kostnad ved varemerke og lignende
+KS;Kontoplan_stat;763;Kontroll-, prøve- og stempelavgift
+KS;Kontoplan_stat;764;Reservert
+KS;Kontoplan_stat;765;Reservert
+KS;Kontoplan_stat;766;Reservert
+KS;Kontoplan_stat;767;Reservert
+KS;Kontoplan_stat;768;Reservert
+KS;Kontoplan_stat;769;Reservert
+KS;Kontoplan_stat;770;Spesielle driftskostnader etter avtale med Finansdepartementet
+KS;Kontoplan_stat;771;Styremøter
+KS;Kontoplan_stat;772;Generalforsamling
+KS;Kontoplan_stat;773;Reservert
+KS;Kontoplan_stat;774;Reservert
+KS;Kontoplan_stat;775;Eiendoms- og festeavgift
+KS;Kontoplan_stat;776;Reservert
+KS;Kontoplan_stat;777;Bank- og kortgebyr
+KS;Kontoplan_stat;778;Reservert (fremtidig eliminering)
+KS;Kontoplan_stat;779;Annen kostnad
+KS;Kontoplan_stat;780;Tap ved avgang av anleggsmidler
+KS;Kontoplan_stat;781;Reservert
+KS;Kontoplan_stat;782;Innkommet på tidligere nedskrevne fordringer
+KS;Kontoplan_stat;783;Konstaterte tap på fordringer
+KS;Kontoplan_stat;784;Avsetning tap på fordringer
+KS;Kontoplan_stat;785;Reservert
+KS;Kontoplan_stat;786;Tap på kontrakter
+KS;Kontoplan_stat;787;Erstatninger
+KS;Kontoplan_stat;788;Reservert
+KS;Kontoplan_stat;789;Reservert
+KS;Kontoplan_stat;800;Inntekter fra eierandeler i selskap m.m.
+KS;Kontoplan_stat;801;Reservert
+KS;Kontoplan_stat;802;"Salgssum ved realisasjon av verdipapirer (bruttobudsjetterte
+virksomheter)"
+KS;Kontoplan_stat;803;Reservert
+KS;Kontoplan_stat;804;Reservert
+KS;Kontoplan_stat;805;Renteinntekt
+KS;Kontoplan_stat;806;Valutagevinst (agio)
+KS;Kontoplan_stat;807;"Renteinntekt av mellomværende med statskassen (motpost 1977)
+(forvaltningsbedrifter)"
+KS;Kontoplan_stat;808;Reservert
+KS;Kontoplan_stat;809;Annen finansinntekt
+KS;Kontoplan_stat;810;Reservert
+KS;Kontoplan_stat;811;Reservert
+KS;Kontoplan_stat;812;Nedskrivning av finansielle anleggsmidler
+KS;Kontoplan_stat;813;Reservert
+KS;Kontoplan_stat;814;Reservert
+KS;Kontoplan_stat;815;Rentekostnad
+KS;Kontoplan_stat;816;Valutatap (disagio)
+KS;Kontoplan_stat;817;"Rentekostnad av mellomværende med statskassen (motpost 1977)
+(forvaltningsbedrifter)"
+KS;Kontoplan_stat;818;"Rentekostnad av statens faste kapital (motpost 1976)
+(forvaltningsbedrifter)"
+KS;Kontoplan_stat;819;Annen finanskostnad
+KS;Kontoplan_stat;820;Reservert
+KS;Kontoplan_stat;821;Tilbakeføring fra statlige fond
+KS;Kontoplan_stat;822;Overføringer fra departementer (kun til bruk for fond)
+KS;Kontoplan_stat;823;Overføringer fra forvaltningsorganer med særskilte fullmakter
+KS;Kontoplan_stat;824;Reservert
+KS;Kontoplan_stat;825;Overføringer fra andre statlige regnskaper
+KS;Kontoplan_stat;826;Reservert
+KS;Kontoplan_stat;827;Andre overføringer etter avtale med DFØ
+KS;Kontoplan_stat;828;Reservert
+KS;Kontoplan_stat;829;Avregning kontogruppe 82, føres mot 1997
+KS;Kontoplan_stat;830;Overføringer fra kommuner
+KS;Kontoplan_stat;831;Overføringer fra fylkeskommuner
+KS;Kontoplan_stat;832;Reservert
+KS;Kontoplan_stat;833;Reservert
+KS;Kontoplan_stat;834;Reservert
+KS;Kontoplan_stat;835;Reservert
+KS;Kontoplan_stat;836;Reservert
+KS;Kontoplan_stat;837;Reservert
+KS;Kontoplan_stat;838;Reservert
+KS;Kontoplan_stat;839;Avregning kontogruppe 83, føres mot 1997
+KS;Kontoplan_stat;840;Skatter
+KS;Kontoplan_stat;841;Trygder og pensjonspremier
+KS;Kontoplan_stat;842;Avgifter
+KS;Kontoplan_stat;843;Reservert
+KS;Kontoplan_stat;844;Gebyrer som ikke inngår som driftsinntekt
+KS;Kontoplan_stat;845;Renteinntekt til statskassen
+KS;Kontoplan_stat;846;Utbytte
+KS;Kontoplan_stat;847;Bøter og inndragninger
+KS;Kontoplan_stat;848;Tilfeldige og andre inntekter
+KS;Kontoplan_stat;849;Avregning kontogruppe 84, føres mot 1997
+KS;Kontoplan_stat;850;Reservert
+KS;Kontoplan_stat;851;Overføringer til statlige fond
+KS;Kontoplan_stat;852;Reservert
+KS;Kontoplan_stat;853;Overføringer til forvaltningsorganer med særskilte fullmakter
+KS;Kontoplan_stat;854;Reservert
+KS;Kontoplan_stat;855;Overføringer til andre statlige regnskaper
+KS;Kontoplan_stat;856;Reservert
+KS;Kontoplan_stat;857;Rentekostnad for statskassen
+KS;Kontoplan_stat;858;Reservert
+KS;Kontoplan_stat;859;Avregning kontogruppe 85
+KS;Kontoplan_stat;870;Tilskudd til kommuner
+KS;Kontoplan_stat;871;Tilskudd til fylkeskommuner
+KS;Kontoplan_stat;872;Tilskudd til ikke-finansielle foretak
+KS;Kontoplan_stat;873;Tilskudd til finansielle foretak
+KS;Kontoplan_stat;874;Tilskudd til husholdninger
+KS;Kontoplan_stat;875;Tilskudd til bedrifter ifm. virusutbrudd
+KS;Kontoplan_stat;876;Tilskudd til ideelle organisasjoner
+KS;Kontoplan_stat;877;Tilskudd til statsforvaltningen
+KS;Kontoplan_stat;878;Tilskudd til utlandet
+KS;Kontoplan_stat;879;Avregning kontogruppe 87
+KS;Kontoplan_stat;880;Disponering (periodens resultat)
+KS;Kontoplan_stat;881;Reservert
+KS;Kontoplan_stat;882;Disponering fond - til/fra opptjent fondskapital
+KS;Kontoplan_stat;883;Reservert
+KS;Kontoplan_stat;884;Reservert
+KS;Kontoplan_stat;885;Avsetning til investeringsformål (forvaltningsbedrifter)
+KS;Kontoplan_stat;886;Til/fra reguleringsfond (forvaltningsbedrifter)
+KS;Kontoplan_stat;887;Disponering øvrig resultat forvaltningsbedrift
+KS;Kontoplan_stat;888;Reservert
+KS;Kontoplan_stat;889;Reservert
+KS;Kontoplan_stat;890;"Avregning bevilgningsfinansiert virksomhet (nettobudsjetterte
+virksomheter)"
+KS;Kontoplan_stat;891;Reservert (nettobudsjetterte virksomheter)
+KS;Kontoplan_stat;892;Reservert (nettobudsjetterte virksomheter)
+KS;Kontoplan_stat;893;Reservert (nettobudsjetterte virksomheter)
+KS;Kontoplan_stat;894;Reservert (nettobudsjetterte virksomheter)
+KS;Kontoplan_stat;895;Avregning med statskassen (bruttobudsjetterte virksomheter)
+KS;Kontoplan_stat;896;Reservert (bruttobudsjetterte virksomheter)
+KS;Kontoplan_stat;897;Driftsresultat post 24 - Kontant til statskassen
+KS;Kontoplan_stat;898;Reservert (bruttobudsjetterte virksomheter)
+KS;Kontoplan_stat;899;Reservert (bruttobudsjetterte virksomheter)

--- a/SAF-T_Financial_1.3/Grouping Category Code/XML/STAT_Grouping_Category_Code.xml
+++ b/SAF-T_Financial_1.3/Grouping Category Code/XML/STAT_Grouping_Category_Code.xml
@@ -1,0 +1,6179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<GroupingCategoryCode xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="Grouping_Category_Code.xsd">
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>100</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>101</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>102</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Konsesjoner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>103</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Patenter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>104</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Programvarelisenser og egenutviklet programvare</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>105</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Varemerker</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>106</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre rettigheter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>107</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Immaterielle eiendeler under utførelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>108</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>109</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>110</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bygninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>111</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>112</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bygningsmessige anlegg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>113</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Anlegg under utførelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>114</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Jord- og skogbrukseiendommer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>115</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tomter og andre grunnarealer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>116</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Boliger inkl. tomter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>117</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Infrastruktureiendeler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>118</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Nasjonaleiendom og kulturminner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>119</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>120</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Maskiner og anlegg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>121</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Maskiner og anlegg under utførelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>122</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Skip, rigger, fly</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>123</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Biler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>124</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre transportmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>125</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inventar</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>126</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fast bygningsinventar med annen avskrivningstid enn bygningen</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>127</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Verktøy og lignende</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>128</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Datamaskiner og annet IKT-utstyr</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>129</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre driftsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>130</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Investeringer i datterselskap</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>131</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kapitalinnskudd</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>132</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Spesielle beholdninger (kapitalregnskapet)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>133</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Investeringer i tilknyttede selskap</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>134</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Obligasjoner (omsettelige verdipapirer)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>135</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Investeringer i aksjer og andeler - kostpris</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>136</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Verdiendring av aksjer og andeler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>137</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Utlån (statsbanker)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>138</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>139</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre langsiktige fordringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>140</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Råvarer og innkjøpte halvfabrikata</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>141</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>142</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Varer og driftsmateriell under tilvirkning</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>143</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>144</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ferdige egentilvirkede varer og driftsmateriell</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>145</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>146</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkjøpte varer (ferdigvarer) og driftsmateriell</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>147</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkjøpte varer (ferdigvarer) og driftsmateriell, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>148</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>149</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>150</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kundefordringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>151</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fordringer vedrørende innkrevingsvirksomhet</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>152</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Motpost konto 151</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>153</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Opptjent, ikke fakturert driftsinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>154</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fordring på ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>155</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>156</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>157</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre kortsiktige fordringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>158</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avsetning tap på fordringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>159</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>160</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Utgående merverdiavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>161</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inngående merverdiavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>162</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>163</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>164</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Oppgjørskonto merverdiavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>165</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>166</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>167</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>168</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>169</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>170</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forskuddsbetalt leie</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>171</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forskuddsbetalt rente</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>172</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>173</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>174</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>175</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Opptjent leieinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>176</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Opptjent renteinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>177</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>178</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>179</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre forskuddsbetalte kostnader</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>180</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kortsiktige finansinvesteringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>181</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>182</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>183</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>184</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>185</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>186</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>187</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>188</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>189</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>190</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kontanter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>191</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre bankinnskudd (utenfor statens konsernkonto)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>192</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bankinnskudd utenlandsk valuta (utenfor statens konsernkonto)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>193</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bankinnskudd - for oppgjørskonto og arbeidskonto - inn (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>194</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bankinnskudd - for oppgjørskonto og arbeidskonto - ut (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>195</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bankinnskudd - for oppgjørskonto og arbeidskonto - inn og ut (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>196</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bankinnskudd - for oppgjørskonto og arbeidskonto (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>197</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forvaltningsbedrifter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1970</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Mellomværende med statskassen - kontant kap 24xx (forvaltningsbedrifter)(IB)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1975</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Årets endring i statens rentebærende kapital (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1976</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Renter av statens faste kapital (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1977</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Renter av mellomværende med statskassen (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1978</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Driftsresultat post 24 - Kontant til statskassen</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>198</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning rapporterte transaksjoner til statsregnskapet - kontantrelatert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1980</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Mellomværende med statskassen - kontant (motpost IB)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1981</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Spesielle ordninger i staten</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1982</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1983</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1984</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Spesielle statskontoer i kapitalregnskapet</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1985</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gruppelivsforsikring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1986</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Arbeidsgiveravgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1987</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Nettoføringsordning for mva.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1988</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Finansskatt på lønn</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1989</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>199</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregnet med statskassen - andre tidsavgrensningsposter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1990</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregnet med statskassen - andre tidsavgrensningsposter (IB)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1991</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inntektsført bevilgning</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1992</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1996</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1997</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkrevingsvirksomhet (motpost konto 829, 839 og 849)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1998</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskuddsforvaltning (motpost konto 859 og 879)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>1999</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning - resultat av periodens aktiviteter (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>200</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innskutt virksomhetskapital</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>201</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>202</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innskutt fondskapital</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>203</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>204</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>205</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Opptjent virksomhetskapital</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>206</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Egenfinansiering av investeringer (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>207</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reguleringsfond (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>208</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Opptjent fondskapital</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>209</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Egenkapital (kapitalregnskapet)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>210</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>211</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Miljøforpliktelser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>212</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>213</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>214</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Statens rentebærende kapital (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>215</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Statens finansiering av immaterielle eiendeler og varige driftsmidler (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>216</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning bevilgningsfinansiert virksomhet (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>217</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ikke inntektsført bevilgning (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>218</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ikke inntektsført tilskudd og overføringer (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>219</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre avsetninger for forpliktelser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>220</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>221</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Obligasjonslån (omsettelige verdipapirer)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>222</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gjeld til finansinstitusjoner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>223</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>224</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>225</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>226</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>227</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lånemellomværende med staten (statsbanker)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>228</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen langsiktig gjeld</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>229</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen langsiktig gjeld, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>230</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>231</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>232</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Obligasjonslån (omsettelige verdipapirer)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>233</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>234</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>235</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>236</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Byggelån</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>237</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>238</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre forpliktelser (kapitalregnskapet)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>239</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen gjeld til finansinstitusjoner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>240</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leverandørgjeld</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>241</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>242</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>243</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>244</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>245</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>246</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>247</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>248</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>249</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>250</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gjeld vedrørende tilskuddsforvaltning og andre overføringer fra staten</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>251</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gjeld vedrørende tilskuddsforvaltning og andre overføringer fra staten, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>252</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>253</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>254</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>255</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Motpost konto 250-251</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>256</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>257</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>258</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>259</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>260</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forskuddstrekk</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>261</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Påleggstrekk</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>262</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bidragstrekk</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>263</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Trygdetrekk/pensjonstrekk (2 %)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>264</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forsikringstrekk</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>265</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Trukket fagforeningskontingent</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>266</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>267</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>268</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>269</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre trekk</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>270</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Utgående merverdiavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>271</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inngående merverdiavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>272</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Grunnlag mva. ved innførsel av varer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>273</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Grunnlag mva. ved innførsel av varer, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>274</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Oppgjørskonto merverdiavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>275</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>276</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>277</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Skyldig arbeidsgiveravgift (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>278</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Påløpt arbeidsgiveravgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>279</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre offentlige avgifter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>280</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avstemmingsdifferanser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>281</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avsatt pensjonspremie til SPK (arbeidsgiverandel)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>282</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avstemmingskonto fakturert pensjonspremie fra SPK</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>283</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>284</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>285</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>286</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>287</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>288</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>289</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>290</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Mottatt forskuddsbetaling</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>291</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gjeld til ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>292</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>293</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>294</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Feriepenger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>295</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Påløpte renter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>296</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Påløpte kostnader</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>297</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Uopptjent inntekt (motpost kontogruppe 35)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>298</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avsetning for forpliktelser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>299</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen kortsiktig gjeld</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>300</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt varer, avgiftspliktig</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>301</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt varer, avgiftspliktig, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>302</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>303</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt tjenester, avgiftspliktig</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>304</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt tjenester, avgiftspliktig, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>305</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>306</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Uttak av varer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>307</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>308</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>309</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>310</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt varer, avgiftsfri</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>311</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt varer, avgiftsfri, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>312</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>313</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt tjenester, avgiftsfri</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>314</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt tjenester, avgiftsfri, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>315</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>316</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>317</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>318</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>319</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>320</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt varer, unntatt avgiftsplikt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>321</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt varer, unntatt avgiftsplikt, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>322</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>323</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt tjenester, unntatt avgiftsplikt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>324</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgsinntekt tjenester, unntatt avgiftsplikt, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>325</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>326</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>327</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>328</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>329</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>330</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Spesielle offentlige avgifter for tilvirkede/solgte varer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>331</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>332</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>333</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>334</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>335</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>336</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>337</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>338</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>339</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>340</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd fra Norges forskningsråd</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>341</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd fra andre statlige virksomheter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>342</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd fra EU</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>343</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd fra kommunale og fylkeskommunale etater</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>344</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd fra organisasjoner og stiftelser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>345</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd fra næringsliv og private</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>346</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gaver og gaveforsterkninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>347</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>348</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>349</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre tilskudd og overføringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>350</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Garanti</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>351</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Service</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>352</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>353</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>354</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>355</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>356</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>357</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>358</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>359</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>360</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leieinntekt fast eiendom</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>361</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leieinntekt fast eiendom, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>362</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leieinntekt fast eiendom, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>363</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leieinntekt andre varige driftsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>364</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen leieinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>365</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>366</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>367</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen driftsrelatert inntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>368</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>369</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>370</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gebyrer med videre - driftsinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>371</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gebyrer med videre - driftsinntekt, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>372</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gebyrer med videre - driftsinntekt, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>373</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gebyrer med videre - driftsinntekt, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>374</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gebyrer med videre - driftsinntekt, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>375</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gebyrinntekt krevd inn på vegne av andre statlige virksomheter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>376</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>377</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>378</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>379</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning konto 375</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>380</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgssum ved avgang anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>381</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gevinst ved avgang av anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>382</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>383</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>384</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>385</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bokført verdi avhendede anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>386</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>387</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overført til tap ved avgang av anleggsmidler (konto 780)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>388</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>389</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>390</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inntekt fra bevilgninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>391</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inntektsført bevilgning benyttet til investering (debitering) (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>392</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>393</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>394</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>395</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inntektsføring av avsetning knyttet til anleggsmidler (avskrivninger)(nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>396</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inntektsføring av resterende avsetning ved avgang anleggsmidler (nettobudsjetterte virksomheter)</CodeDescription>
+<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>397</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>398</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre inntekter fra bevilgninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>399</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>400</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkjøp av råvarer og halvfabrikater</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>401</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkjøp av råvarer og halvfabrikater, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>402</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkjøp av råvarer og halvfabrikater, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>403</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkjøp av råvarer og halvfabrikater, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>404</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>405</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>406</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Frakt, toll og spedisjon</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>407</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>408</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>409</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Beholdningsendring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>410</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Varer under tilvirkning</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>411</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Varer under tilvirkning, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>412</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Varer under tilvirkning, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>413</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Varer under tilvirkning, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>414</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>415</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>416</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Frakt, toll og spedisjon</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>417</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>418</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>419</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Beholdningsendring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>420</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ferdig egentilvirkede varer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>421</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ferdig egentilvirkede varer, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>422</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ferdig egentilvirkede varer, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>423</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ferdig egentilvirkede varer, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>424</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>425</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>426</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Frakt, toll og spedisjon</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>427</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>428</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>429</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Beholdningsendring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>430</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>431</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>432</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>433</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>434</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>435</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>436</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>437</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forbruk av innkjøpte varer og tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>438</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>439</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Beholdningsendring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>450</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fremmedytelse og underentreprise</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>451</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fremmedytelse og underentreprise, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>452</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fremmedytelse og underentreprise, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>453</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fremmedytelse og underentreprise, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>454</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fremmedytelse og underentreprise, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>455</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>456</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>457</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>458</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>459</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Beholdningsendring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>460</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen periodisering</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>461</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>462</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>463</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>464</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>465</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>466</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>467</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>468</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>469</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Beholdningsendring, egentilvirkede anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>470</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>471</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>472</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Konsesjoner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>473</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Patenter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>474</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Programvarelisenser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>475</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Varemerker</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>476</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre rettigheter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>477</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>478</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>479</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>480</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bygninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>481</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>482</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bygningsmessige anlegg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>483</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>484</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Jord- og skogbrukseiendommer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>485</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tomter og andre grunnarealer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>486</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Boliger inkl. tomter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>487</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Infrastruktureiendeler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>488</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Nasjonaleiendom og kulturminner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>489</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>490</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Maskiner og anlegg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>491</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>492</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Skip, rigger, fly</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>493</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Biler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>494</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre transportmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>495</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inventar</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>496</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fast bygningsinventar med annen levetid enn bygningen</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>497</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Verktøy og lignende</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>498</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Datamaskiner  og annet IKT-utstyr</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>499</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre driftsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>500</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn fast ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>501</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn fast ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>502</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn fast ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>503</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn fast ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>504</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn balanseført ved egenutvikling av anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>505</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overtid fast ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>506</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overtid fast ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>507</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>508</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Feriepenger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>509</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Periodiseringskonto lønn</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>510</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn midlertidig ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>511</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn midlertidig ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>512</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn midlertidig ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>513</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lønn midlertidig ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>514</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>515</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overtid midlertidig ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>516</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overtid midlertidig ansatte, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>517</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>518</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Feriepenger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>519</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Periodiseringskonto lønn</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>520</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fri bil</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>521</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fri elektronisk kommunikasjon (telefon, mobiltelefon mv.)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>522</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fri avis</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>523</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fri losji og bolig</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>524</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Rentefordel</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>525</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gruppelivsforsikring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>526</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>527</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>528</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen fordel i arbeidsforhold</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>529</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Motkonto for gruppe 52</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>530</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Styrer, råd og utvalg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>531</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Styrer, råd og utvalg, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>532</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>533</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Honorarer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>534</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Honorarer, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>535</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>536</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Virkemidler ved omstilling i staten (lønnsinnberettet av virksomheten)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>537</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>538</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>539</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen oppgavepliktig godtgjørelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>540</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Arbeidsgiveravgift innberettede ytelser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>541</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Arbeidsgiveravgift påløpte ytelser</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>542</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Pensjonspremie til SPK</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>543</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>544</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Pensjonspremie for pensjonsordninger utenfor SPK</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>545</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>546</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inntekter til pensjonsordninger i staten (kun til bruk for SPK)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>547</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Utgifter til pensjonsordninger i staten (kun til bruk for SPK)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>548</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Utgifter til pensjonsordninger i staten (kun til bruk for SPK), fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>549</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Finansskatt på lønn</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>550</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen kostnadsgodtgjørelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>551</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>552</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>553</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Godtgjørelse til innkalte, klienter og innsatte m.m.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>554</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Godtgjørelse til innkalte, klienter og innsatte m.m., fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>555</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Godtgjørelse til innkalte, klienter og innsatte m.m., fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>556</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>557</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ventelønn (lønnsinnberettet av andre enn virksomheten)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>558</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>559</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>570</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lærlingtilskudd</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>571</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Arbeidsmarkedstiltak</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>572</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilretteleggingstilskudd</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>573</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>574</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>575</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>576</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>577</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>578</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>579</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre offentlige tilskudd</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>580</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Refusjon av sykepenger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>581</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Refusjon av foreldrepenger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>582</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>583</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>584</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>585</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>586</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>587</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>588</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>589</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen refusjon vedrørende arbeidskraft</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>590</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gaver til ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>591</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kantinekostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>592</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gruppelivsforsikring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>593</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Yrkesskadepremie</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>594</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>595</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>596</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Velferdstiltak</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>597</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>598</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>599</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen personalkostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>600</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avskrivning på immaterielle eiendeler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>601</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avskrivning på bygninger og annen fast eiendom</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>602</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avskrivning på bygninger og annen fast eiendom, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>603</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avskrivning på infrastruktureiendeler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>604</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avskrivning på maskiner og transportmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>605</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avskrivning på driftsløsøre, inventar, verktøy o.l.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>606</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>607</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Nedskrivning av varige driftsmidler og immaterielle eiendeler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>608</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>609</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>610</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Frakt, transport og forsikring ved vareforsendelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>611</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Toll og spedisjon ved vareforsendelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>612</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>613</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>614</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Frakt, transport m.m. ved utdeling av driftsmateriell</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>615</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>616</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>617</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>618</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>619</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen frakt- og transportkostnad ved salg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>620</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Elektrisitet</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>621</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gass</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>622</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Fyringsolje</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>623</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kull, koks</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>624</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Ved</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>625</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bensin, diesel</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>626</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Vann</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>627</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>628</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>629</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annet brensel</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>630</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie lokaler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>631</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie lokaler fra Statsbygg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>632</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Renovasjon, vann, avløp o.l.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>633</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>634</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lys, varme</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>635</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>636</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Renhold, vakthold, vaktmestertjenester</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>637</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>638</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>639</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen kostnad lokaler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>640</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie maskiner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>641</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie inventar</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>642</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie av datasystemer (årlige lisenser m.m.)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>643</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie av datamaskiner og annet IKT-utstyr</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>644</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie av andre kontormaskiner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>645</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie av biler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>646</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Leie av andre transportmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>647</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>648</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>649</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen leiekostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>650</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Maskiner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>651</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Verktøy og lignende</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>652</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Programvare (anskaffelse)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>653</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>654</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inventar</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>655</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Datamaskiner og annet IKT-utstyr (PCer, mobiltelefoner, nettbrett m.m.)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>656</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre kontormaskiner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>657</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Arbeidsklær og verneutstyr</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>658</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annet driftsmateriale</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>659</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annet driftsmateriale, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>660</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold egne bygninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>661</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold egne bygninger, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>662</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold egne bygninger, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>663</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold leide lokaler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>664</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold infrastruktureiendeler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>665</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold infrastruktureiendeler, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>666</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold maskiner og anlegg</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>667</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold maskiner og anlegg, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>668</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold skip, rigger, fly</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>669</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reparasjon og vedlikehold annet</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>670</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Konsulenttjenester innen økonomi, revisjon og juss</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>671</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Konsulenttjenester til utvikling av programvare, IKT-løsninger mv.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>672</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Konsulenttjenester til organisasjonsutvikling, kommunikasjonsrådgivning mv.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>673</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre konsulenttjenester</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>674</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innleie av vikarer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>675</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kjøp av tjenester til løpende driftsoppgaver, IKT</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>676</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kjøp av lønns- og regnskapstjenester</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>677</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>678</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kjøp av andre fremmede tjenester</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>679</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kjøp av andre fremmede tjenester, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>680</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kontorrekvisita</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>681</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>682</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Trykksak</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>683</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annonser, kunngjøringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>684</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Aviser, tidsskrifter, bøker o.l.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>685</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Aviser, tidsskrifter, bøker o.l. i bibliotek</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>686</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Møter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>687</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kurs og seminarer for egne ansatte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>688</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kurs og seminarer for eksterne deltakere</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>689</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen kontorkostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>690</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Telefoni og datakommunikasjon, samband, internett</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>691</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>692</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>693</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>694</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Porto</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>695</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>696</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>697</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>698</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>699</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>700</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Drivstoff</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>701</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>702</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Vedlikehold</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>703</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>704</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forsikring</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>705</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>706</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>707</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>708</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>709</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen kostnad transportmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>710</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bilgodtgjørelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>711</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>712</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>713</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reisekostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>714</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reisekostnad, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>715</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Diettkostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>716</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Diettkostnad, fortsettelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>717</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>718</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>719</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen kostnadsgodtgjørelse</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>730</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgskostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>731</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>732</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reklame- og markedsføringskostnader</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>733</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>734</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>735</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Representasjon</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>736</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>737</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>738</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>739</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>740</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kontingent</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>741</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gave</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>742</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>743</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>744</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>745</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>746</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>747</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>748</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>749</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>750</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Forsikringspremie</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>751</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>752</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>753</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>754</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>755</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Garantikostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>756</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Servicekostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>757</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>758</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>759</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>760</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Lisensavgift og royalties (ikke programvarelisenser, jf. 642)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>761</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Patentkostnad ved egen patent</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>762</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kostnad ved varemerke og lignende</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>763</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Kontroll-, prøve- og stempelavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>764</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>765</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>766</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>767</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>768</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>769</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>770</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Spesielle driftskostnader etter avtale med Finansdepartementet</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>771</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Styremøter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>772</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Generalforsamling</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>773</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>774</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>775</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Eiendoms- og festeavgift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>776</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>777</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bank- og kortgebyr</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>778</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (fremtidig eliminering)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>779</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen kostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>780</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tap ved avgang av anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>781</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>782</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Innkommet på tidligere nedskrevne fordringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>783</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Konstaterte tap på fordringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>784</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avsetning tap på fordringer</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>785</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>786</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tap på kontrakter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>787</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Erstatninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>788</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>789</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>800</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Inntekter fra eierandeler i selskap m.m.</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>801</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>802</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Salgssum ved realisasjon av verdipapirer (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>803</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>804</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>805</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Renteinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>806</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Valutagevinst (agio)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>807</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Renteinntekt av mellomværende med statskassen (motpost 1977) (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>808</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>809</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen finansinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>810</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>811</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>812</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Nedskrivning av finansielle anleggsmidler</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>813</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>814</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>815</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Rentekostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>816</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Valutatap (disagio)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>817</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Rentekostnad av mellomværende med statskassen (motpost 1977) (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>818</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Rentekostnad av statens faste kapital (motpost 1976) (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>819</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Annen finanskostnad</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>820</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>821</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilbakeføring fra statlige fond</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>822</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer fra departementer (kun til bruk for fond)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>823</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer fra forvaltningsorganer med særskilte fullmakter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>824</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>825</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer fra andre statlige regnskaper</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>826</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>827</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Andre overføringer etter avtale med DFØ</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>828</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>829</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning kontogruppe 82, føres mot 1997</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>830</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer fra kommuner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>831</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer fra fylkeskommuner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>832</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>833</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>834</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>835</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>836</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>837</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>838</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>839</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning kontogruppe 83, føres mot 1997</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>840</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Skatter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>841</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Trygder og pensjonspremier</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>842</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avgifter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>843</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>844</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Gebyrer som ikke inngår som driftsinntekt</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>845</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Renteinntekt til statskassen</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>846</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Utbytte</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>847</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Bøter og inndragninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>848</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilfeldige og andre inntekter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>849</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning kontogruppe 84, føres mot 1997</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>850</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>851</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer til statlige fond</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>852</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>853</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer til forvaltningsorganer med særskilte fullmakter</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>854</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>855</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Overføringer til andre statlige regnskaper</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>856</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>857</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Rentekostnad for statskassen</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>858</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>859</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning kontogruppe 85</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>870</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til kommuner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>871</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til fylkeskommuner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>872</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til ikke-finansielle foretak</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>873</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til finansielle foretak</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>874</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til husholdninger</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>875</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til bedrifter ifm. virusutbrudd</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>876</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til ideelle organisasjoner</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>877</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til statsforvaltningen</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>878</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Tilskudd til utlandet</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>879</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning kontogruppe 87</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>880</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Disponering (periodens resultat)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>881</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>882</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Disponering fond - til/fra opptjent fondskapital</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>883</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>884</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>885</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avsetning til investeringsformål (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>886</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Til/fra reguleringsfond (forvaltningsbedrifter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>887</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Disponering øvrig resultat forvaltningsbedrift</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>888</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>889</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>890</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning bevilgningsfinansiert virksomhet (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>891</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>892</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>893</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>894</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (nettobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>895</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Avregning med statskassen (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>896</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>897</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Driftsresultat post 24 - Kontant til statskassen</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>898</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+	<Account>
+		<GroupingCategory>KS</GroupingCategory>
+		<CategoryDescription ISOLanguageCode="NOB">stat</CategoryDescription>
+		<CategoryDescription ISOLanguageCode="ENG">NA</CategoryDescription>
+		<GroupingCode>899</GroupingCode>
+		<CodeDescription ISOLanguageCode="NOB">Reservert (bruttobudsjetterte virksomheter)</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">NA</CodeDescription>
+	</Account>
+</GroupingCategoryCode>


### PR DESCRIPTION
Kontoplan for statlige virksomheter, for mapping i SAF-T Financial. Listene er utarbeidet i formatene csv og xml.