### PR TITLE
Corrected wrong text - code 6350

### DIFF
--- a/SAF-T_Financial_1.3/Grouping Category Code/CSV/naeringsspesifikasjon.csv
+++ b/SAF-T_Financial_1.3/Grouping Category Code/CSV/naeringsspesifikasjon.csv
@@ -189,7 +189,7 @@ annenDriftskostnad;Næringsspesifikasjon;Income Statement;6140;Frakt og transpor
 annenDriftskostnad;Næringsspesifikasjon;Income Statement;6200;Energi, brensel mv. vedrørende produksjon;Power and fuel, etc. for manufacture
 annenDriftskostnad;Næringsspesifikasjon;Income Statement;6300;Leie lokale;Rent, premises
 annenDriftskostnad;Næringsspesifikasjon;Income Statement;6340;Lys, varme;Lighting and heating
-annenDriftskostnad;Næringsspesifikasjon;Income Statement;6350;Strøm og oppvarming;Electricity and heating
+annenDriftskostnad;Næringsspesifikasjon;Income Statement;6350;IT kostnader;IT costs
 annenDriftskostnad;Næringsspesifikasjon;Income Statement;6395;Renovasjon, vann, avløp, renhold mv.;Waste disposal, water, sewage, cleaning etc.
 annenDriftskostnad;Næringsspesifikasjon;Income Statement;6400;Leie maskiner, inventar og utstyr o.l.;Rental of machines, fixtures and fittings, etc.
 annenDriftskostnad;Næringsspesifikasjon;Income Statement;6440;Langtidsleie/leasing av bil;Long-term rental/leasing of vehicle
@@ -439,7 +439,7 @@ endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.60.20;Andre egenkapitaltransaksjoner - Mottatt konsernbidrag;Other equity transactions – Received group contribution
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.70.00;Andre egenkapitaltransaksjoner - Kundeutbytte;Other equity transactions – Customer dividends
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.90.00;Andre egenkapitaltransaksjoner - Andre;Other equity transactions – Other
-balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;1.11.00;Kontanter;Cash
+balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;01.11.00;Kontanter;Cash
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;1.16.00;Bankinnskudd;Bank deposits
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;2.20.40;Fondsobligasjoner klassifisert som egenkapital;Hybrid capital classified as equity capital
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;2.20.51;Andeler i rentefond;Units in interest funds

--- a/SAF-T_Financial_1.3/Grouping Category Code/CSV/naeringsspesifikasjon.csv
+++ b/SAF-T_Financial_1.3/Grouping Category Code/CSV/naeringsspesifikasjon.csv
@@ -439,7 +439,7 @@ endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.60.20;Andre egenkapitaltransaksjoner - Mottatt konsernbidrag;Other equity transactions – Received group contribution
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.70.00;Andre egenkapitaltransaksjoner - Kundeutbytte;Other equity transactions – Customer dividends
 endringIEgenkapitalInnenBankOgForsikring;Næringsspesifikasjon;Income Statement;9.08.0.90.00;Andre egenkapitaltransaksjoner - Andre;Other equity transactions – Other
-balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;01.11.00;Kontanter;Cash
+balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;1.11.00;Kontanter;Cash
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;1.16.00;Bankinnskudd;Bank deposits
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;2.20.40;Fondsobligasjoner klassifisert som egenkapital;Hybrid capital classified as equity capital
 balanseverdiForBankOgForsikringseiendel;Næringsspesifikasjon;Income Statement;2.20.51;Andeler i rentefond;Units in interest funds

--- a/SAF-T_Financial_1.3/Grouping Category Code/XML/naeringsspesifikasjon.xml
+++ b/SAF-T_Financial_1.3/Grouping Category Code/XML/naeringsspesifikasjon.xml
@@ -1525,8 +1525,8 @@
 		<CategoryDescription ISOLanguageCode="NOB">Næringsspesifikasjon</CategoryDescription>
 		<CategoryDescription ISOLanguageCode="ENG">Income Statement</CategoryDescription>
 		<GroupingCode>6350</GroupingCode>
-		<CodeDescription ISOLanguageCode="NOB">Strøm og oppvarming</CodeDescription>
-		<CodeDescription ISOLanguageCode="ENG">Electricity and heating</CodeDescription>
+		<CodeDescription ISOLanguageCode="NOB">IT kostnader</CodeDescription>
+		<CodeDescription ISOLanguageCode="ENG">IT costs</CodeDescription>
 	</Account>
 	<Account>
 		<GroupingCategory>annenDriftskostnad</GroupingCategory>


### PR DESCRIPTION
Corrected wrong text for code 6350, from "Electricity and heating" to "IT costs" (only Petroleum).